### PR TITLE
Numpy array support & python 2.7 support

### DIFF
--- a/apng/__init__.py
+++ b/apng/__init__.py
@@ -127,7 +127,7 @@ def make_chunk(type, data):
 	"""
 	out = struct.pack("!I", len(data))
 	data = type.encode("latin-1") + data
-	out += data + struct.pack("!I", binascii.crc32(data))
+	out += data + struct.pack("!I", binascii.crc32(data) & 0xffffffff)
 	return out
 	
 class PNG:

--- a/apng/__init__.py
+++ b/apng/__init__.py
@@ -40,8 +40,9 @@ def is_png(png):
 	"""Test if ``png`` is a valid PNG file by checking the signature.
 	
 	:arg png: If ``png`` is a :any:`path-like object` or :any:`file-like object`
-		object, read the content into bytes.
-	:type png: path-like, file-like, or bytes
+		or a numpy array, read the content into bytes. Numpy arrays
+		are only supported if the :py:mod:`numpy` module is installed.
+	:type png: path-like, file-like, numpy array, or bytes
 	:rtype: bool
 	"""
 	if isinstance(png, str) or hasattr(png, "__fspath__"):


### PR DESCRIPTION
Here are two patches, one to support numpy arrays as input, and the other to provide python 2.7 compatibility (its binascii.crc32 function returns a value that is greater than 32 bits, apparently. See https://docs.python.org/2/library/binascii.html#binascii.crc32)